### PR TITLE
marks module as complete

### DIFF
--- a/src/Module/components/ModuleDefault.vue
+++ b/src/Module/components/ModuleDefault.vue
@@ -214,7 +214,7 @@ export default defineComponent({
       ]
     };
 
-    const { adkData } = getModAdk(
+    const { adkData, adkIndex } = getModAdk(
       props,
       ctx.emit,
       'Pitches',
@@ -319,6 +319,10 @@ export default defineComponent({
         title: 'Success!',
         text: 'Successfully marked as final draft!'
       });
+      adkData.value.update(() => ({
+        isComplete: true,
+        adkIndex: adkIndex
+      }))
       // IndexVal.value = adkData.value.vlaueDrafts.length - 1;
     }
 

--- a/src/Module/types.ts
+++ b/src/Module/types.ts
@@ -2,6 +2,6 @@ export default interface MongoDoc {
   data: {
     adks: Record<string, any>[];
   };
-  update: () => Promise<any>;
+  update: (shouldMarkAsComplete?:any) => Promise<any>;
   changeStream: any;
 }


### PR DESCRIPTION
I have not been able to test this module, so I'm just taking my best guess as to how we want to evaluate the completeness of this module. In this case, I assume that calling `finalDraft()` will mark it as complete, which is whenever the user has put enough valid responses and clicks the "Make Final Draft" button. 

# TODO
- [ ] test module (module is incomplete at the time of this PR)
- [ ] bump up npm package version